### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 install:
   - travis_retry composer self-update
   # Install a polyfill for Mongo extension on PHP 7
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then travis_retry composer require "alcaeus/mongo-php-adapter=^1.0.0" --ignore-platform-reqs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then travis_retry composer config "platform.ext-mongo" "1.6.16" && composer require alcaeus/mongo-php-adapter; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then travis_retry composer update; fi
   - composer info -i
 


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.